### PR TITLE
Feat: generate space model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem 'puma', '~> 5.0'
 # rack-cors
 gem 'rack-cors'
 
+# cancancan authorization gem
+gem 'cancancan'
+
 # devise gems
 gem 'devise'
 gem 'devise-jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     bootsnap (1.11.1)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.3.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     debug (1.4.0)
@@ -199,6 +200,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
+  cancancan
   debug
   devise
   devise-jwt

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -1,6 +1,6 @@
 class SpacesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_space, only: %i[ show update destroy ]
+  before_action :set_space, only: %i[show update destroy]
   load_and_authorize_resource
 
   # GET /spaces
@@ -41,13 +41,14 @@ class SpacesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_space
-      @space = Space.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def space_params
-      params.require(:space).permit(:name, :price, :image, :removed, :description)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_space
+    @space = Space.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def space_params
+    params.require(:space).permit(:name, :price, :image, :removed, :description)
+  end
 end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -1,0 +1,51 @@
+class SpacesController < ApplicationController
+  before_action :set_space, only: %i[ show update destroy ]
+
+  # GET /spaces
+  def index
+    @spaces = Space.all
+
+    render json: @spaces
+  end
+
+  # GET /spaces/1
+  def show
+    render json: @space
+  end
+
+  # POST /spaces
+  def create
+    @space = Space.new(space_params)
+
+    if @space.save
+      render json: @space, status: :created, location: @space
+    else
+      render json: @space.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /spaces/1
+  def update
+    if @space.update(space_params)
+      render json: @space
+    else
+      render json: @space.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /spaces/1
+  def destroy
+    @space.destroy
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_space
+      @space = Space.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def space_params
+      params.require(:space).permit(:name, :price, :image, :removed, :users_id)
+    end
+end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -1,6 +1,7 @@
 class SpacesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_space, only: %i[ show update destroy ]
+  load_and_authorize_resource
 
   # GET /spaces
   def index

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -1,4 +1,5 @@
 class SpacesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_space, only: %i[ show update destroy ]
 
   # GET /spaces
@@ -15,7 +16,7 @@ class SpacesController < ApplicationController
 
   # POST /spaces
   def create
-    @space = Space.new(space_params)
+    @space = current_user.spaces.create(space_params)
 
     if @space.save
       render json: @space, status: :created, location: @space
@@ -46,6 +47,6 @@ class SpacesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def space_params
-      params.require(:space).permit(:name, :price, :image, :removed, :users_id)
+      params.require(:space).permit(:name, :price, :image, :removed, :description)
     end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Ability
   include CanCan::Ability
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+    user ||= User.new
+
+    can :read, Space, public: true # readaing the spaces is public meanig that everyone can read it
+    return unless user.admin?
+
+    can :manage, Space # finally we give all remaining permissions only to the admins
+  end
+end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -1,3 +1,9 @@
 class Space < ApplicationRecord
+  # Validations
+  validates :name, presence: { message: 'field can not be blank' }
+  validates :price, presence: { message: 'field can not be blank' }
+  validates :image, presence: { message: 'field can not be blank' }
+  validates :description, presence: { message: 'field can not be blank' }
+
   belongs_to :users
 end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -1,0 +1,3 @@
+class Space < ApplicationRecord
+  belongs_to :users
+end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -5,5 +5,5 @@ class Space < ApplicationRecord
   validates :image, presence: { message: 'field can not be blank' }
   validates :description, presence: { message: 'field can not be blank' }
 
-  belongs_to :users
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   validates :name, presence: { message: 'This field can not be blank' }
 
-  has_many :spaces
+  has_many :spaces, dependent: :destroy
 
   def admin?
     role == 'admin'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
          :jwt_authenticatable, jwt_revocation_strategy: self
 
   validates :name, presence: { message: 'This field can not be blank' }
+
+  has_many :spaces
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
   validates :name, presence: { message: 'This field can not be blank' }
 
   has_many :spaces
+
+  def admin?
+    role == 'admin'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :spaces
   devise_for :users, path: '', path_names: {
     sign_in: 'login',
     sign_out: 'logout',

--- a/db/migrate/20220330041945_create_spaces.rb
+++ b/db/migrate/20220330041945_create_spaces.rb
@@ -1,0 +1,13 @@
+class CreateSpaces < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spaces do |t|
+      t.string :name, null: false
+      t.decimal :price, null: false
+      t.string :image, null: false
+      t.boolean :removed, null: false, default: false
+      t.references :users, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220330041945_create_spaces.rb
+++ b/db/migrate/20220330041945_create_spaces.rb
@@ -6,7 +6,7 @@ class CreateSpaces < ActiveRecord::Migration[7.0]
       t.decimal :price, null: false
       t.string :image, null: false
       t.boolean :removed, null: false, default: false
-      t.references :users, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20220330041945_create_spaces.rb
+++ b/db/migrate/20220330041945_create_spaces.rb
@@ -2,6 +2,7 @@ class CreateSpaces < ActiveRecord::Migration[7.0]
   def change
     create_table :spaces do |t|
       t.string :name, null: false
+      t.string :description, null: false
       t.decimal :price, null: false
       t.string :image, null: false
       t.boolean :removed, null: false, default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,10 +20,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_30_041945) do
     t.decimal "price", null: false
     t.string "image", null: false
     t.boolean "removed", default: false, null: false
-    t.bigint "users_id", null: false
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["users_id"], name: "index_spaces_on_users_id"
+    t.index ["user_id"], name: "index_spaces_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -42,5 +42,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_30_041945) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "spaces", "users", column: "users_id"
+  add_foreign_key "spaces", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_27_231030) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_30_041945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "spaces", force: :cascade do |t|
+    t.string "name", null: false
+    t.decimal "price", null: false
+    t.string "image", null: false
+    t.boolean "removed", default: false, null: false
+    t.bigint "users_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["users_id"], name: "index_spaces_on_users_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -30,4 +41,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_27_231030) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "spaces", "users", column: "users_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_30_041945) do
 
   create_table "spaces", force: :cascade do |t|
     t.string "name", null: false
+    t.string "description", null: false
     t.decimal "price", null: false
     t.string "image", null: false
     t.boolean "removed", default: false, null: false

--- a/test/controllers/spaces_controller_test.rb
+++ b/test/controllers/spaces_controller_test.rb
@@ -1,35 +1,45 @@
-require "test_helper"
+require 'test_helper'
 
 class SpacesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @space = spaces(:one)
   end
 
-  test "should get index" do
+  test 'should get index' do
     get spaces_url, as: :json
     assert_response :success
   end
 
-  test "should create space" do
-    assert_difference("Space.count") do
-      post spaces_url, params: { space: { image: @space.image, name: @space.name, price: @space.price, removed: @space.removed, users_id: @space.users_id } }, as: :json
+  test 'should create space' do
+    assert_difference('Space.count') do
+      post spaces_url,
+           params: { space: { image: @space.image,
+                              name: @space.name,
+                              price: @space.price,
+                              removed: @space.removed,
+                              users_id: @space.users_id } }, as: :json
     end
 
     assert_response :created
   end
 
-  test "should show space" do
+  test 'should show space' do
     get space_url(@space), as: :json
     assert_response :success
   end
 
-  test "should update space" do
-    patch space_url(@space), params: { space: { image: @space.image, name: @space.name, price: @space.price, removed: @space.removed, users_id: @space.users_id } }, as: :json
+  test 'should update space' do
+    patch space_url(@space),
+          params: { space: { image: @space.image,
+                             name: @space.name,
+                             price: @space.price,
+                             removed: @space.removed,
+                             users_id: @space.users_id } }, as: :json
     assert_response :success
   end
 
-  test "should destroy space" do
-    assert_difference("Space.count", -1) do
+  test 'should destroy space' do
+    assert_difference('Space.count', -1) do
       delete space_url(@space), as: :json
     end
 

--- a/test/controllers/spaces_controller_test.rb
+++ b/test/controllers/spaces_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class SpacesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @space = spaces(:one)
+  end
+
+  test "should get index" do
+    get spaces_url, as: :json
+    assert_response :success
+  end
+
+  test "should create space" do
+    assert_difference("Space.count") do
+      post spaces_url, params: { space: { image: @space.image, name: @space.name, price: @space.price, removed: @space.removed, users_id: @space.users_id } }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should show space" do
+    get space_url(@space), as: :json
+    assert_response :success
+  end
+
+  test "should update space" do
+    patch space_url(@space), params: { space: { image: @space.image, name: @space.name, price: @space.price, removed: @space.removed, users_id: @space.users_id } }, as: :json
+    assert_response :success
+  end
+
+  test "should destroy space" do
+    assert_difference("Space.count", -1) do
+      delete space_url(@space), as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/test/fixtures/spaces.yml
+++ b/test/fixtures/spaces.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  price: 9.99
+  image: MyString
+  removed: false
+  users: one
+
+two:
+  name: MyString
+  price: 9.99
+  image: MyString
+  removed: false
+  users: two

--- a/test/models/space_test.rb
+++ b/test/models/space_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SpaceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/space_test.rb
+++ b/test/models/space_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class SpaceTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
In this feature branch I:
 

- [x] Generated `Space` model according to the DB schema above
- [x] Generate items controller with CRUD actions.
- While sending the `params` there is no need to specify `user_id`, the app will create `space` from the  looged-in`current_user`
- [x] Made sure that only users with a role of admin can manage the CRUD actions

**1st scenario: regular user tries to create `space`**
![Screenshot from 2022-03-30 10-17-04](https://user-images.githubusercontent.com/67608876/160758295-bedc58b9-ba9d-46e7-93cc-d54ab4051ced.png)
**2st scenario: user with the role of admin tries to create `space`**
![Screenshot from 2022-03-30 10-21-11](https://user-images.githubusercontent.com/67608876/160758396-001132ec-747d-4a48-8375-a065652fe1e5.png)
![Screenshot from 2022-03-30 10-22-49](https://user-images.githubusercontent.com/67608876/160758413-517bde27-b882-446f-acd3-42be080184dc.png)


- [x] Set up respective routes